### PR TITLE
Replaced Mesh.Optimize with MeshUtility.Optimize

### DIFF
--- a/MeshSaver/Editor/MeshSaverEditor.cs
+++ b/MeshSaver/Editor/MeshSaverEditor.cs
@@ -28,8 +28,8 @@ public static class MeshSaverEditor {
 
 		Mesh meshToSave = (makeNewInstance) ? Object.Instantiate(mesh) as Mesh : mesh;
 		
-        if (optimizeMesh)
-            meshToSave.Optimize();
+		if (optimizeMesh)
+		     MeshUtility.Optimize(meshToSave);
         
 		AssetDatabase.CreateAsset(meshToSave, path);
 		AssetDatabase.SaveAssets();


### PR DESCRIPTION
Since Unity 5.6 [Mesh.Optimize() no longer exists](https://docs.unity3d.com/ScriptReference/Mesh.Optimize.html). It has been replaced by [MeshUtility.Optimize(mesh)](https://docs.unity3d.com/ScriptReference/MeshUtility.Optimize.html).